### PR TITLE
feat: add NSColor support for cross-platform compatibility

### DIFF
--- a/output/RadixColors.swift
+++ b/output/RadixColors.swift
@@ -5770,4 +5770,32 @@ extension Color {
         ))
     }
 }
+#elseif canImport(AppKit)
+extension NSColor {
+    convenience init(
+        light lightModeColor: @escaping @autoclosure () -> NSColor,
+        dark darkModeColor: @escaping @autoclosure () -> NSColor
+    ) {
+        self.init(name: nil) { appearance in
+            switch appearance.name {
+            case .darkAqua, .vibrantDark, .accessibilityHighContrastDarkAqua, .accessibilityHighContrastVibrantDark:
+                return darkModeColor()
+            default:
+                return lightModeColor()
+            }
+        }
+    }
+}
+
+extension Color {
+    init(
+        light lightModeColor: @escaping @autoclosure () -> Color,
+        dark darkModeColor: @escaping @autoclosure () -> Color
+    ) {
+        self.init(NSColor(
+            light: NSColor(lightModeColor()),
+            dark: NSColor(darkModeColor())
+        ))
+    }
+}
 #endif


### PR DESCRIPTION
## Summary

Adds **AppKit/NSColor** support alongside **UIKit/UIColor** to enable the dynamic color initializers to work on both iOS and macOS.

### Problem

The current  extension only supports , which is exclusive to iOS/tvOS/watchOS and does not work on macOS. This limits the library's usability for SwiftUI apps targeting multiple Apple platforms.

### Solution

Added conditional compilation using :

- **iOS/tvOS/watchOS**: Uses  with 
- **macOS**: Uses  with  to detect dark mode

Both implementations provide the same dynamic color behavior, checking for light vs dark appearance and returning the appropriate color.

### Changes

- Added  convenience initializer with light/dark mode support
- Added macOS-specific  extension using 
- Maintained backward compatibility with existing iOS code

### Testing

Tested on:
- [x] iOS builds (UIColor path)
- [x] macOS builds (NSColor path)
- [x] No breaking changes to existing API

Closes #1