### PR TITLE
Add AppKit (NSColor/Color) extensions to generation script

### DIFF
--- a/.github/workflows/eslint-check.yml
+++ b/.github/workflows/eslint-check.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '*'
+  pull_request:
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -13,23 +16,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v4
         with:
           version: 8
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'pnpm'
 
       - name: Run Install
-        run: |
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Lint Check
-        run: |
-          pnpm lint
+        run: pnpm lint
 

--- a/.github/workflows/generation-parity-check.yml
+++ b/.github/workflows/generation-parity-check.yml
@@ -1,0 +1,41 @@
+name: Generation Parity Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  check-generation-parity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+
+      - name: Run Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Generation Script
+        run: pnpm build
+
+      - name: Check for Differences
+        run: |
+          if git diff --exit-code output/; then
+            echo "Generation output matches committed files."
+          else
+            echo "::error::Generation output differs from committed files. Please run 'pnpm build' and commit the updated output."
+            exit 1
+          fi

--- a/generator/helper.ts
+++ b/generator/helper.ts
@@ -47,5 +47,33 @@ extension Color {
         ))
     }
 }
+#elseif canImport(AppKit)
+extension NSColor {
+    convenience init(
+        light lightModeColor: @escaping @autoclosure () -> NSColor,
+        dark darkModeColor: @escaping @autoclosure () -> NSColor
+    ) {
+        self.init(name: nil) { appearance in
+            switch appearance.name {
+            case .darkAqua, .vibrantDark, .accessibilityHighContrastDarkAqua, .accessibilityHighContrastVibrantDark:
+                return darkModeColor()
+            default:
+                return lightModeColor()
+            }
+        }
+    }
+}
+
+extension Color {
+    init(
+        light lightModeColor: @escaping @autoclosure () -> Color,
+        dark darkModeColor: @escaping @autoclosure () -> Color
+    ) {
+        self.init(NSColor(
+            light: NSColor(lightModeColor()),
+            dark: NSColor(darkModeColor())
+        ))
+    }
+}
 #endif
 `;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

This PR addresses three issues:

### 1. Add AppKit extensions to generation script (`generator/helper.ts`)

The output file `RadixColors.swift` contained an `#elseif canImport(AppKit)` block with `NSColor` and `Color` extensions for macOS light/dark mode support, but the generation script only had the UIKit block. Re-running the generator would lose the AppKit extensions.

Added to the `helperExtensions` template:
- **`NSColor` convenience init** — uses `NSAppearance.Name` to resolve light/dark mode
- **`Color` init** — bridges SwiftUI `Color` light/dark through `NSColor`

Verified locally: running the build produces output identical to the committed file (zero diff).

### 2. Fix failing CI on `main` (ESLint workflow)

The `pnpm/action-setup@v2.2.2` action fails with `ERR_INVALID_THIS` when fetching from the npm registry. Updated all GitHub Actions to current stable versions:

| Action | Old | New |
|--------|-----|-----|
| `pnpm/action-setup` | v2.2.2 | v4 |
| `actions/checkout` | v3 | v4 |
| `actions/setup-node` | v2 | v4 |

Also added a `pull_request` trigger to the ESLint workflow so it runs on PRs targeting `main`.

### 3. Add generation parity CI check

New workflow (`.github/workflows/generation-parity-check.yml`) that runs on PRs:
1. Installs dependencies
2. Runs `pnpm build` (the generation script)
3. Checks `git diff output/` — fails if the generated output differs from committed files

This prevents future mismatches between the generation script and its output.

# Related Issues

* Fixes failing CI on `main` (ESLint workflow)

# Contribution Checklist

- [x] My changes generate no new warnings.
- [x] My code builds and runs properly on my machine.
- [x] I have documented my code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1331970d-176a-4a72-8500-755ccd5fa8bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1331970d-176a-4a72-8500-755ccd5fa8bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

